### PR TITLE
Websocket 超时无消息重连

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -128,3 +128,6 @@ dmypy.json
 # Pyre type checker
 .pyre/
 .vscode/settings.json
+
+# vim
+*.swp

--- a/.gitignore
+++ b/.gitignore
@@ -128,6 +128,3 @@ dmypy.json
 # Pyre type checker
 .pyre/
 .vscode/settings.json
-
-# vim
-*.swp

--- a/vnpy_websocket/websocket_client.py
+++ b/vnpy_websocket/websocket_client.py
@@ -10,6 +10,8 @@ from asyncio import (
     set_event_loop,
     set_event_loop,
     run_coroutine_threadsafe,
+    create_task,
+    wait_for,
     TimeoutError,
     AbstractEventLoop
 )
@@ -193,7 +195,7 @@ class WebsocketClient:
 
                 while is_connected:
                     # 持续处理收到的数据
-                    msg = await self._ws.receive(timeout=self._receive_timeout)
+                    msg = await wait_for(self._ws.receive(), timeout=self._receive_timeout)
                     if msg.type not in (WSMsgType.CLOSE, WSMsgType.CLOSING, WSMsgType.CLOSED):
                         text: str = msg.data
                         self._record_last_received_text(text)

--- a/vnpy_websocket/websocket_client.py
+++ b/vnpy_websocket/websocket_client.py
@@ -10,17 +10,10 @@ from asyncio import (
     set_event_loop,
     set_event_loop,
     run_coroutine_threadsafe,
-    create_task,
-    wait_for,
-    TimeoutError,
     AbstractEventLoop
 )
 
-from aiohttp import (
-    ClientSession,
-    ClientWebSocketResponse,
-    WSMsgType
-)
+from aiohttp import ClientSession, ClientWebSocketResponse
 
 
 class WebsocketClient:
@@ -42,7 +35,6 @@ class WebsocketClient:
         self._session: ClientSession = None
         self._ws: ClientWebSocketResponse = None
         self._loop: AbstractEventLoop = None
-        self._receive_timeout = 30
 
         self._proxy: str = None
         self._ping_interval: int = 60  # 秒
@@ -191,30 +183,18 @@ class WebsocketClient:
 
                 # 调用连接成功回调
                 self.on_connected()
-                is_connected = True
 
-                while is_connected:
-                    # 持续处理收到的数据
-                    msg = await wait_for(self._ws.receive(), timeout=self._receive_timeout)
-                    if msg.type not in (WSMsgType.CLOSE, WSMsgType.CLOSING, WSMsgType.CLOSED):
-                        text: str = msg.data
-                        self._record_last_received_text(text)
+                # 持续处理收到的数据
+                async for msg in self._ws:
+                    text: str = msg.data
+                    self._record_last_received_text(text)
 
-                        data: dict = self.unpack_data(text)
-                        self.on_packet(data)
-                    else:
-                        is_connected = False
+                    data: dict = self.unpack_data(text)
+                    self.on_packet(data)
 
                 # 移除Websocket连接对象
                 self._ws = None
-                # 调用连接断开回调
-                self.on_disconnected()
-            except TimeoutError:
-                # WebSocket 接收消息超时，关闭连接，进入下个循环重连
-                # 关闭连接
-                run_coroutine_threadsafe(self._ws.close(), self._loop)
-                # 移除Websocket连接对象
-                self._ws = None
+
                 # 调用连接断开回调
                 self.on_disconnected()
             # 处理捕捉到的异常

--- a/vnpy_websocket/websocket_client.py
+++ b/vnpy_websocket/websocket_client.py
@@ -10,8 +10,6 @@ from asyncio import (
     set_event_loop,
     set_event_loop,
     run_coroutine_threadsafe,
-    create_task,
-    wait_for,
     TimeoutError,
     AbstractEventLoop
 )
@@ -195,7 +193,7 @@ class WebsocketClient:
 
                 while is_connected:
                     # 持续处理收到的数据
-                    msg = await wait_for(self._ws.receive(), timeout=self._receive_timeout)
+                    msg = await self._ws.receive(timeout=self._receive_timeout)
                     if msg.type not in (WSMsgType.CLOSE, WSMsgType.CLOSING, WSMsgType.CLOSED):
                         text: str = msg.data
                         self._record_last_received_text(text)

--- a/vnpy_websocket/websocket_client.py
+++ b/vnpy_websocket/websocket_client.py
@@ -202,7 +202,7 @@ class WebsocketClient:
                 self.on_disconnected()
             # 捕获 receive 超时异常
             except TimeoutError:
-                run_coroutine_threadsafe(self._ws.close())
+                run_coroutine_threadsafe(self._ws.close(), self._loop)
                 # 移除Websocket连接对象
                 self._ws = None
                 # 调用连接断开回调


### PR DESCRIPTION
优化点

- ws 接受消息超时重试机制；
- 超时时间可通过 _receive_timeout 设置，默认 30 秒；

大部分 ws 消息服务都提供了如 pingpong 的心跳心跳消息，心跳的时间间隔应小于 _receive_timeout 防止重连。

相关 issue [建议接收服务器数据的时候增加超时机制](https://github.com/vnpy/vnpy_websocket/issues/3)